### PR TITLE
types comply with typescript strict mode

### DIFF
--- a/yaioc.d.ts
+++ b/yaioc.d.ts
@@ -1,18 +1,18 @@
 
 export interface IContainer {
 
-    register<TYPE extends Function>(object: TYPE);
-    register<TYPE extends Function>(object: { default: TYPE });
-    register<TYPE>(name: string, object: TYPE);
+    register<TYPE extends Function>(object: TYPE): void;
+    register<TYPE extends Function>(object: { default: TYPE }): void;
+    register<TYPE>(name: string, object: TYPE): void;
 
-    registerConstructor<TYPE extends Function>(constructorFunction: { new(...args: any[]): TYPE }, dependencyNames?: string[]);
-    registerConstructor<TYPE extends Function>(name: string, constructorFunction: { new(...args: any[]): TYPE }, dependencyNames?: string[]);
+    registerConstructor<TYPE extends Function>(constructorFunction: { new(...args: any[]): TYPE }, dependencyNames?: string[]): void;
+    registerConstructor<TYPE extends Function>(name: string, constructorFunction: { new(...args: any[]): TYPE }, dependencyNames?: string[]): void;
 
-    registerValue<TYPE>(name: string, object: TYPE);
+    registerValue<TYPE>(name: string, object: TYPE): void;
 
-    registerFactory<TYPE>(name: string, factory: (...args: any[]) => TYPE, dependencyNames?: string[]);
+    registerFactory<TYPE>(name: string, factory: (...args: any[]) => TYPE, dependencyNames?: string[]): void;
 
-    registerAdaptor<TYPE>(name: string, adaptor: TYPE);
+    registerAdaptor<TYPE>(name: string, adaptor: TYPE): void;
 
     cache(): IContainer;
 


### PR DESCRIPTION
Hi, I'm using `yaioc` and it has been nice and easy so far. I'd like to enable typescript in strict mode - there are a few little issues with the current types.

### How are the types better after the PR ?
just try to run `npx -p typescript@4 tsc --noEmit --strict  ./yaioc.d.ts` and you'll see the difference (erros) before and after the PR.

### Note
I noticed that the latest release is probably based on `development` branch - which already contains some fixes. I assume it was just forgotten to be merged to `master`. Hence this PR is based on that dev branch. 