### PR TITLE
type exported Container class

### DIFF
--- a/yaioc.d.ts
+++ b/yaioc.d.ts
@@ -22,11 +22,19 @@ export interface IContainer {
 
 }
 
+interface IYaiocClassConstructor {
+    new(childContainer?: IContainer): IContainer
+}
+
 export interface IYaiocConstructor {
     (): IContainer;
     container(childContainer?: IContainer): IContainer;
+    Container: IYaiocClassConstructor;
 }
 
 export interface IContainerAdaptor<T> {
     getComponentInstance(conatiner: IContainer, target?: string): T
 }
+
+declare var defaultExport: IYaiocConstructor;
+export default defaultExport;


### PR DESCRIPTION
## PR Contents
- define a type for exported `Container` class - which can easily be used or extended if someone needs to
- define types for the exported JS code. Currently, there are just defined types that need to be used manually 

### Note
I noticed that the latest release is probably based on development branch - which already contains some fixes. I assume it was just forgotten to be merged to master. Hence this PR is based on that dev branch.